### PR TITLE
Create fifo as RUN_AS_USER, so watchdogs can use fifos

### DIFF
--- a/src/glb_daemon.c
+++ b/src/glb_daemon.c
@@ -42,6 +42,12 @@ void glb_daemon_start (const glb_cnf_t* cnf)
         struct passwd *pw = getpwnam(RUN_AS_USER);
         if ( pw ) {
             glb_log_info ("Changing effective user to '%s'", RUN_AS_USER);
+            if (setgid(pw->pw_gid))
+            {
+                glb_log_fatal ("Failed to change group: %d (%s)",
+                               errno, strerror(errno));
+                exit(EXIT_FAILURE);
+            }
             if (setuid(pw->pw_uid))
             {
                 glb_log_fatal ("Failed to change user: %d (%s)",


### PR DESCRIPTION
We require watchdogs to change weight of the Galera servers, so they should have access to the fifo glbd creates.