### PR TITLE
Use memcpy instead of strncpy to avoid stringop-truncation error

### DIFF
--- a/src/glb_dst.c
+++ b/src/glb_dst.c
@@ -46,7 +46,7 @@ glb_dst_parse (glb_dst_t* dst, const char* s, uint16_t default_port)
         return -EINVAL;
     }
 
-    strncpy (addr_str, s, addr_len); // this now contains only host address
+    memcpy (addr_str, s, addr_len); // this now contains only host address
 
     ret = 1;
     if (NULL == endptr) // string is over


### PR DESCRIPTION
Compilation fails with GCC 9 for -Werror=stringop-truncation in
glb_dst.c. This is because strncpy() is used in a way which
does not copy terminating NUL into dst buffer. To avoid the
error, replace strncpy() with memcpy().