### PR TITLE
wait for connection on local address only

### DIFF
--- a/files/glbd.sh
+++ b/files/glbd.sh
@@ -61,11 +61,15 @@ else
 fi
 
 wait_for_connections_to_drop() {
-	while (netstat -na | grep -m 1 ":$LISTEN_PORT " > /dev/null); do
-		echo "[`date`] $prog: waiting for lingering sockets to clear up..."
-		sleep 1s
-	done;
-	return 0
+    _LISTEN_ADDR=$LISTEN_ADDR
+    if [ "$_LISTEN_ADDR" = "$LISTEN_PORT" ]; then
+        _LISTEN_ADDR=":"$LISTEN_PORT
+    fi
+    while (netstat -na | awk '{ print $4 }' | grep "$_LISTEN_ADDR" > /dev/null); do
+        echo "[`date`] $prog: waiting for lingering sockets to clear up..."
+        sleep 1s
+    done;
+    return 0
 }
 
 stop() {


### PR DESCRIPTION
Let's say glb is listening on 0.0.0.0:3306, and there is another program connecting to 192.168.1.3:3306. It doesn't work if we try restart glb in this case, E.g.: netstan -an

```
tcp        0      0 192.168.1.1:42388        192.168.1.3:3306         ESTABLISHED
```

The reason is that **netstat -an | grep -m 1 ':3306'** matches 192.168.1.3:3306, which is external connection.